### PR TITLE
doc: fix typo in cmp key mapping example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ specs = {
 -- to invoke the configuration manually.
 require('cmp').setup {
     mapping = {
-        ["A-y"] = require('minuet').make_cmp_map()
+        ["<A-y>"] = require('minuet').make_cmp_map()
         -- and your other keymappings
     },
 }


### PR DESCRIPTION
Fix a minor typo `s/A-y/<A-y>` for `cmp` mapping in README.