### PR TITLE
feat: cancel completion jobs to run new ones

### DIFF
--- a/lua/minuet/backends/common.lua
+++ b/lua/minuet/backends/common.lua
@@ -2,7 +2,7 @@ local M = {}
 local utils = require 'minuet.utils'
 local job = require 'plenary.job'
 local config = require('minuet').config
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 
 M.current_jobs = {}
 

--- a/lua/minuet/backends/common.lua
+++ b/lua/minuet/backends/common.lua
@@ -114,7 +114,6 @@ function M.complete_openai_fim_base(options, get_text_fn, context_before_cursor,
     -- Terminate all current jobs before starting new ones
     for _, job_to_kill in ipairs(M.current_jobs) do
         utils.notify('Canceling completion job ' .. job_to_kill.pid, 'verbose')
-        ---@diagnostic disable-next-line: undefined-field
         uv.kill(job_to_kill.pid, 15) -- 15 - term signal
     end
 

--- a/lua/minuet/backends/gemini.lua
+++ b/lua/minuet/backends/gemini.lua
@@ -59,6 +59,8 @@ local function make_request_data()
 end
 
 function M.complete(context_before_cursor, context_after_cursor, callback)
+    common.terminate_all_jobs()
+
     local options, data = make_request_data()
 
     local context = utils.make_chat_llm_shot(context_before_cursor, context_after_cursor)
@@ -101,15 +103,17 @@ function M.complete(context_before_cursor, context_after_cursor, callback)
         table.insert(args, config.proxy)
     end
 
-    job:new({
+    local new_job = job:new {
         command = 'curl',
         args = args,
-        on_exit = vim.schedule_wrap(function(response, exit_code)
+        on_exit = vim.schedule_wrap(function(exited_job, exit_code)
+            common.remove_job(exited_job)
+
             local items_raw
             if options.stream then
-                items_raw = utils.stream_decode(response, exit_code, data_file, 'Gemini', get_text_fn)
+                items_raw = utils.stream_decode(exited_job, exit_code, data_file, 'Gemini', get_text_fn)
             else
-                items_raw = utils.no_stream_decode(response, exit_code, data_file, 'Gemini', get_text_fn)
+                items_raw = utils.no_stream_decode(exited_job, exit_code, data_file, 'Gemini', get_text_fn)
             end
 
             if not items_raw then
@@ -125,7 +129,10 @@ function M.complete(context_before_cursor, context_after_cursor, callback)
 
             callback(items)
         end),
-    }):start()
+    }
+
+    common.register_job(new_job)
+    new_job:start()
 end
 
 return M

--- a/lua/minuet/backends/huggingface.lua
+++ b/lua/minuet/backends/huggingface.lua
@@ -36,6 +36,8 @@ if not M.is_available() then
 end
 
 M.complete_completion = function(context_before_cursor, context_after_cursor, callback)
+    common.terminate_all_jobs()
+
     local options, data = make_request_data()
     local language = utils.add_language_comment()
     local tab = utils.add_tab_comment()
@@ -98,11 +100,13 @@ M.complete_completion = function(context_before_cursor, context_after_cursor, ca
         table.insert(args, config.proxy)
     end
 
-    job:new({
+    local new_job = job:new {
         command = 'curl',
         args = args,
-        on_exit = vim.schedule_wrap(function(response, exit_code)
-            local json = utils.no_stream_decode(response, exit_code, data_file, 'huggingface', function(json)
+        on_exit = vim.schedule_wrap(function(exited_job, exit_code)
+            common.remove_job(exited_job)
+
+            local json = utils.no_stream_decode(exited_job, exit_code, data_file, 'huggingface', function(json)
                 return json
             end)
 
@@ -131,7 +135,10 @@ M.complete_completion = function(context_before_cursor, context_after_cursor, ca
 
             callback(items)
         end),
-    }):start()
+    }
+
+    common.register_job(new_job)
+    new_job:start()
 end
 
 M.complete = function(context_before_cursor, context_after_cursor, callback)

--- a/lua/minuet/utils.lua
+++ b/lua/minuet/utils.lua
@@ -322,7 +322,7 @@ function M.no_stream_decode(response, exit_code, data_file, provider, get_text_f
     success, result_str = pcall(get_text_fn, json)
 
     if not success or not result_str then
-        M.notify(provider .. ' returns no text: ' .. vim.inspect(json), 'error', vim.log.levels.INFO)
+        M.notify(provider .. ' returns no text: ' .. vim.inspect(json), 'verbose', vim.log.levels.INFO)
         return
     end
 
@@ -363,7 +363,8 @@ function M.stream_decode(response, exit_code, data_file, provider, get_text_fn)
     local result_str = #result > 0 and table.concat(result) or nil
 
     if not result_str then
-        M.notify(provider .. ' returns no text on streaming: ' .. vim.inspect(responses), 'error', vim.log.levels.INFO)
+        M.notify(provider .. ' returns no text on streaming: ' .. vim.inspect(responses), 'verbose', vim.log.levels.INFO)
+        return
     end
 
     return result_str


### PR DESCRIPTION
This patch assumes that whenever `complete()` is triggered, currently running completion requests are obsolete and their result should not be processed anymore.

Therefore, this patch adds a mechanism to keep track of running completion jobs and terminates them, if they are still running when `complete()` is called again.

This fixes a race condition where old complete requests might still contribute to the suggestions even though they are not up to date anymore.

This reduces LLM load even when `throttle` and `debounce` are set to `0` because there are always only `n_completions` jobs running at the same time.