### PR TITLE
feat: display suggestions as they arrive

### DIFF
--- a/lua/minuet/backends/common.lua
+++ b/lua/minuet/backends/common.lua
@@ -129,21 +129,7 @@ function M.complete_openai_fim_base(options, get_text_fn, context_before_cursor,
     end
 
     local items = {}
-    local request_complete = 0
     local n_completions = config.n_completions
-    local has_called_back = false
-
-    local function check_and_callback()
-        if request_complete >= n_completions and not has_called_back then
-            has_called_back = true
-
-            items = M.filter_context_sequences_in_items(items, context_after_cursor)
-
-            items = utils.remove_spaces(items)
-
-            callback(items)
-        end
-    end
 
     for _ = 1, n_completions do
         local args = {
@@ -170,9 +156,6 @@ function M.complete_openai_fim_base(options, get_text_fn, context_before_cursor,
             command = 'curl',
             args = args,
             on_exit = vim.schedule_wrap(function(response, exit_code)
-                -- Increment the request_send counter
-                request_complete = request_complete + 1
-
                 local result
 
                 if options.stream then
@@ -185,9 +168,12 @@ function M.complete_openai_fim_base(options, get_text_fn, context_before_cursor,
                     table.insert(items, result)
                 end
 
-                check_and_callback()
+                items = M.filter_context_sequences_in_items(items, context_after_cursor)
+                items = utils.remove_spaces(items)
+                callback(items)
             end),
         }):start()
     end
 end
+
 return M

--- a/lua/minuet/virtualtext.lua
+++ b/lua/minuet/virtualtext.lua
@@ -184,7 +184,9 @@ local function trigger(bufnr)
 
         local ctx = get_ctx()
         ctx.suggestions = data
-        ctx.choice = 1
+        if not ctx.choice then
+            ctx.choice = 1
+        end
         ctx.shown_choices = {}
 
         update_preview()


### PR DESCRIPTION
This patch removes the mechanism to show suggestions once all completions have been collected. Instead, it allows suggestions to be displayed incrementally as they come in. This approach leads to faster user feedback.