### PR TITLE
Refactor OpenAI FIM Compatible Backend to have advanced configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,8 +860,11 @@ text `/completions` endpoint, **not** `/chat/completions` endpoint, so system
 prompts and few-shot examples are not applicable.
 
 For example, you can set the `end_point` to
-`http://localhost:11434/v1/completions` to use `ollama`, or set it to
-`http://localhost:8012/v1/completions` to use `llama.cpp`.
+`http://localhost:11434/v1/completions` to use `ollama`,
+`http://localhost:8012/v1/completions` to use `llama.cpp`,
+or `https://api.deepinfra.com/v1/inference/` for DeepInfra.
+Read the Advanced Customizing section below for setting up
+DeepInfra and other non-OpenAI compatible FIM APIs.
 
 Cmdline completion is available for models supported by these providers:
 `deepseek`, `ollama`, and `siliconflow`.
@@ -920,6 +923,72 @@ provider_options = {
         },
     },
 }
+```
+
+</details>
+
+<details>
+<summary>Advanced Customizing</summary>
+
+The `openai_fim_compatible` backend also supports additional customization
+options to accommodate providers with varying API requirements:
+
+- **`header_transform`**: A function that takes the `endpoint`
+  (string) and `headers` (table) as arguments and returns a
+  modified `endpoint` and `headers`. Useful for providers
+  like DeepInfra that require the model name appended to the endpoint URL.
+- **`body_transform`**: A function that takes the request
+  `data` (table) and returns a modified version.
+  This allows renaming or restructuring fields
+  (e.g., renaming `prompt` to `input` for DeepInfra).
+- **`get_text_fn`**: Can now be a table with `stream` and `no_stream` keys,
+  each mapping to a function that extracts text from the provider's
+  JSON response.
+
+Below is an example configuration for using DeepInfra with the
+`Qwen/Qwen2.5-Coder-32B-Instruct` model, demonstrating the advanced
+customization options:
+
+```lua
+openai_fim_compatible = {
+    model = "Qwen/Qwen2.5-Coder-32B-Instruct",
+    end_point = "https://api.deepinfra.com/v1/inference/",
+    api_key = "DEEPINFRA_API_KEY",
+    name = "DeepInfra",
+    stream = true,
+    template = {
+        prompt = function(context_before_cursor, context_after_cursor)
+            return "<|fim_prefix|>"
+                .. context_before_cursor
+                .. "<|fim_suffix|>"
+                .. context_after_cursor
+                .. "<|fim_middle|>"
+        end,
+        suffix = false,
+    },
+    header_transform = function(endpoint, headers)
+        -- Append model name to endpoint as required by DeepInfra
+        return endpoint .. "Qwen/Qwen2.5-Coder-32B-Instruct", headers
+    end,
+    body_transform = function(data)
+        -- DeepInfra expects 'input' instead of 'prompt'
+        return {
+            input = data.prompt,
+            stream = data.stream,
+        }
+    end,
+    get_text_fn = {
+        no_stream = function(json)
+            -- DeepInfra non-streaming response format
+            return json.results[1].generated_text
+        end,
+        stream = function(json)
+            -- DeepInfra streaming response format
+            return json.token.text
+        end,
+    },
+    n_completions = 2, -- Request 2 completions
+},
 ```
 
 </details>

--- a/lua/minuet/backends/common.lua
+++ b/lua/minuet/backends/common.lua
@@ -261,26 +261,6 @@ function M.complete_openai_fim_base(options, get_text_fn, context, callback)
     })
 
     for idx = 1, n_completions do
-        local args = {
-            '-L',
-            options.end_point,
-            '-H',
-            'Content-Type: application/json',
-            '-H',
-            'Accept: application/json',
-            '-H',
-            'Authorization: Bearer ' .. utils.get_api_key(options.api_key),
-            '--max-time',
-            tostring(config.request_timeout),
-            '-d',
-            '@' .. data_file,
-        }
-
-        if config.proxy then
-            table.insert(args, '--proxy')
-            table.insert(args, config.proxy)
-        end
-
         local new_job = Job:new {
             command = 'curl',
             args = args,

--- a/lua/minuet/lsp.lua
+++ b/lua/minuet/lsp.lua
@@ -78,7 +78,11 @@ M.request_handler['textDocument/completion'] = function(_, params, callback, not
             -- inserted, potentially leading to miscalculations of the word
             -- boundaries before and after the cursor, and thus, incorrect
             -- behavior.
-            if params.context.triggerKind ~= vim.lsp.protocol.CompletionTriggerKind.TriggerCharacter then
+            if
+                -- mini.completion does not provide context field
+                not params.context
+                or (params.context.triggerKind ~= vim.lsp.protocol.CompletionTriggerKind.TriggerCharacter)
+            then
                 data = vim.tbl_map(function(item)
                     return utils.prepend_to_complete_word(item, context.lines_before)
                 end, data)


### PR DESCRIPTION
Hello! First apologies for the delay.I said I’d hopefully get it done in 48 hours, but it looks like I was drifting on Pluto’s schedule! :)

Following discussion in #59, I’ve reworked my initial implementation to extend the existing `openai_fim_compatible` backend instead of creating a separate one for DeepInfra-FIM.

**Here is some details changes**:

- Added support for three new configuration options to allow customization of requests and responses:
  - `header_transform`: A function to modify the endpoint and headers.
  - `body_transform`: A function to transform the request body.
  - `get_text_fn`: Now supports a table format with `stream` and `no_stream` keys, allowing custom text extraction from JSON responses for both streaming and non-streaming cases.
- If these options are not provided, the backend falls back to the default OpenAI-compatible behavior.

I've tested with both `gpt-3.5-turbo-instruct` and `Qwen/Qwen2.5-Coder-32B-Instruct` from deepinfra, so hopefully all is good. :)