### PR TITLE
fix: code completion for .heex files

### DIFF
--- a/lua/minuet/utils.lua
+++ b/lua/minuet/utils.lua
@@ -108,7 +108,7 @@ function M.add_language_comment()
     end
 
     -- escape % in comment string
-    local commentstring = vim.bo.commentstring:gsub('^%% ', '%%%% '):gsub('%%$', '%%%%')
+    local commentstring = vim.bo.commentstring:gsub('%%', '%%%%'):gsub('%%%%s', '%%s')
 
     return string.format(commentstring, string.format('language: %s', vim.bo.ft))
 end
@@ -128,7 +128,7 @@ function M.add_tab_comment()
             return '# ' .. tab_comment
         end
 
-        local commentstring = vim.bo.commentstring:gsub('^%% ', '%%%% '):gsub('%%$', '%%%%')
+        local commentstring = vim.bo.commentstring:gsub('%%', '%%%%'):gsub('%%%%s', '%%s')
 
         return string.format(commentstring, tab_comment)
     end
@@ -139,7 +139,7 @@ function M.add_tab_comment()
             return '# ' .. tab_comment
         end
 
-        local commentstring = vim.bo.commentstring:gsub('^%% ', '%%%% '):gsub('%%$', '%%%%')
+        local commentstring = vim.bo.commentstring:gsub('%%', '%%%%'):gsub('%%%%s', '%%s')
 
         return string.format(commentstring, tab_comment)
     end


### PR DESCRIPTION
Currently completion throws the following error in `.heex` files (elixir's templating language):

```
Error executing vim.schedule lua callback: ...eovimPackages/start/minuet-ai.nvim/lua/minuet/config.lua:67: invalid option '%!' to 'format'
stack traceback:
	[C]: in function 'add_language_comment'
	...eovimPackages/start/minuet-ai.nvim/lua/minuet/config.lua:67: in function 'prompt'
	...ages/start/minuet-ai.nvim/lua/minuet/backends/common.lua:175: in function 'complete_openai_fim_base'
	...et-ai.nvim/lua/minuet/backends/openai_fim_compatible.lua:44: in function 'complete'
	...Packages/start/minuet-ai.nvim/lua/minuet/virtualtext.lua:189: in function 'trigger'
	...Packages/start/minuet-ai.nvim/lua/minuet/virtualtext.lua:248: in function ''
	vim/_editor.lua: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```

The problem is that `vim.bo.commentstring` returns `<%!-- %s --%>` for `.heex` files. To solve that instead escaping only first and last `%`, the code in this PR is escaping every `%` and unescaping only `%s`