### PR TITLE
fix(virtualtext): respect virtualtext highlight group inline

### DIFF
--- a/lua/minuet/virtualtext.lua
+++ b/lua/minuet/virtualtext.lua
@@ -154,7 +154,7 @@ local function update_preview(ctx)
         extmark.virt_text[1][1] = extmark.virt_text[1][1] .. ' ' .. annot
     end
 
-    extmark.hl_mode = 'combine'
+    extmark.hl_mode = 'replace'
 
     api.nvim_buf_set_extmark(0, internal.ns_id, cursor_line - 1, cursor_col - 1, extmark)
 


### PR DESCRIPTION
Currently, virtualtext highlights groups are not completely respected. This is especially apparent when displaying virtualtext inside a set of parentheses (or related), since their background and foreground color are merged and take priority.

With this fix, we ensure virtualtext always looks like virtualtext.

**Current behaviour** (notice how the suggested text inside the curly braces is not formatted like the virtualtext below, even though it is text from the same LLM suggestion)
![Screenshot 2025-04-19 205125](https://github.com/user-attachments/assets/b8f98b75-109e-4416-a2f3-9d16aff9c00b)

**New behaviour** (text correctly formatted)
![Screenshot 2025-04-19 205254](https://github.com/user-attachments/assets/29c27b27-e1f1-4689-a6c7-bfe4919d8483)


