### PR TITLE
feat: implement action accept word

### DIFF
--- a/lua/minuet/config.lua
+++ b/lua/minuet/config.lua
@@ -182,6 +182,7 @@ local M = {
         auto_trigger_ignore_ft = {},
         keymap = {
             accept = nil,
+            accept_word = nil,
             accept_line = nil,
             -- accept n lines (prompts for number)
             accept_n_lines = nil,

--- a/lua/minuet/virtualtext.lua
+++ b/lua/minuet/virtualtext.lua
@@ -348,7 +348,7 @@ function accept_word_extract_portion(suggestion)
     if suggestion:match '^%s*\n' then
         text_to_accept = suggestion:match '^(%s*\n)'
     else
-        text_to_accept = suggestion:match '^(%S+%s*)'
+        text_to_accept = suggestion:match '^([%w]+[%p]?%s*)' or suggestion:match '^(%S+%s*)'
         if not text_to_accept or #text_to_accept == 0 then
             text_to_accept = suggestion
         end


### PR DESCRIPTION
This PR adds a new **“accept word”** action. It lets you accept the next word or any of these special characters: `.` `,` `(` `)` `{` `}` `[` `]`. While doing so, it preserves the existing code preview, so you don’t incur the cost of regenerating a fresh suggestion on every acceptance.

During implementation, I ran into an issue with **cmp‑nvim**: if the accepted text contained a snippet (or similar construct), cmp‑nvim wouldn’t finish the word from the suggestion. The workaround is to configure cmp‑nvim so that it only opens when explicitly invoked (for example, via a command), rather than automatically on every keystroke.

https://github.com/user-attachments/assets/64be4536-9d3e-43bb-8932-d3e5b832ecaf

I don’t have much experience with Lua, so I’m struggling a bit, if you spot any improvements or issues, feel free to let me know!

