### PR TITLE
[#88] Place cursor at end of inserted text when accepting single-line virtual text completion

### DIFF
--- a/lua/minuet/virtualtext.lua
+++ b/lua/minuet/virtualtext.lua
@@ -307,8 +307,9 @@ function action.accept(n_lines)
     vim.schedule_wrap(function()
         api.nvim_buf_set_text(0, line, col, line, col, suggestions)
         if #suggestions == 1 then
-            -- move to eol. \15 is Ctrl-o
-            api.nvim_feedkeys(ctrl_o .. '$', 'n', false)
+           -- move cursor to end of inserted suggestion
+            local new_col = col + #suggestions[1]
+            api.nvim_win_set_cursor(0, {line + 1, new_col})
         else
             -- move cursor to the end of inserted text
             api.nvim_feedkeys(string.rep(down_key, #suggestions - 1), 'n', false)


### PR DESCRIPTION
A small change was added to the `accept` function to place the cursor at the end of the completion.


Before the change:

https://github.com/user-attachments/assets/953ee52a-059c-4ba6-a3df-a3efbd6b4213

After the change:

https://github.com/user-attachments/assets/07cc6212-ac44-48e8-a7bf-00c9a56180ce

