### PR TITLE
[fix] : Minute-AI are not being displayed in the Blink-Cmp completion menu

### DIFF
--- a/lua/minuet/blink.lua
+++ b/lua/minuet/blink.lua
@@ -105,11 +105,12 @@ function M:get_completions(ctx, callback)
 
             local items = {}
             for _, result in ipairs(new_data) do
-                local item_lines = vim.split(result, '\n')
+                local cleaned = result:gsub('^[\n\r]+', '')
+                local item_lines = vim.split(cleaned, '\n')
                 local item_label
 
                 if #item_lines == 1 then
-                    item_label = result
+                    item_label = cleaned
                 else
                     item_label = vim.fn.strcharpart(item_lines[1], 0, max_label_width - #multi_lines_indicators)
                         .. multi_lines_indicators
@@ -122,7 +123,7 @@ function M:get_completions(ctx, callback)
                     kind_hl = 'BlinkCmpItemKindMinuet',
                     documentation = {
                         kind = 'markdown',
-                        value = '```' .. (vim.bo.ft or '') .. '\n' .. result .. '\n```',
+                        value = '```' .. (vim.bo.ft or '') .. '\n' .. cleaned .. '\n```',
                     },
                 })
             end

--- a/lua/minuet/cmp.lua
+++ b/lua/minuet/cmp.lua
@@ -86,7 +86,7 @@ function M:complete(ctx, callback)
                     label = result,
                     documentation = {
                         kind = cmp.lsp.MarkupKind.Markdown,
-                        value = '```' .. (vim.bo.ft or '') .. '\n' .. result .. '\n```',
+                        value = '```' .. (vim.bo.ft or '') .. '\n' .. result:gsub('^[\n\r]+', '') .. '\n```',
                     },
                     insertTextMode = lsp.InsertTextMode.AdjustIndentation,
                     cmp = {

--- a/lua/minuet/lsp.lua
+++ b/lua/minuet/lsp.lua
@@ -110,11 +110,12 @@ M.request_handler['textDocument/completion'] = function(_, params, callback, not
 
             local items = {}
             for _, result in ipairs(new_data) do
-                local item_lines = vim.split(result, '\n')
+                local cleaned = result:gsub('^[\n\r]+', '')
+                local item_lines = vim.split(cleaned, '\n')
                 local item_label
 
                 if #item_lines == 1 then
-                    item_label = result
+                    item_label = cleaned
                 else
                     item_label = vim.fn.strcharpart(item_lines[1], 0, max_label_width - #multi_lines_indicators)
                         .. multi_lines_indicators
@@ -127,7 +128,7 @@ M.request_handler['textDocument/completion'] = function(_, params, callback, not
                     insertTextMode = 1,
                     documentation = {
                         kind = 'markdown',
-                        value = '```' .. (vim.bo.ft or '') .. '\n' .. result .. '\n```',
+                        value = '```' .. (vim.bo.ft or '') .. '\n' .. cleaned .. '\n```',
                     },
                     kind = vim.lsp.protocol.CompletionItemKind.Text,
                     detail = config.provider_options[config.provider].name or config.provider,


### PR DESCRIPTION
- Use first non-blank line as label source; truncate on multi-line and append indicator

issue link : https://github.com/milanglacier/minuet-ai.nvim/issues/109

tested on blink : 

before :

<img width="582" height="433" alt="mainOd" src="https://github.com/user-attachments/assets/d9aebc81-e307-42f0-ad5e-417d381a05c2" />

after : 

<img width="731" height="433" alt="image" src="https://github.com/user-attachments/assets/d6c25898-d3f6-42cb-a8c6-4cca59587d7a" />
