### PR TITLE
fix(virtualtext): move cursor correctly after accepting suggestions

### DIFF
--- a/lua/minuet/virtualtext.lua
+++ b/lua/minuet/virtualtext.lua
@@ -383,7 +383,7 @@ function action.accept(n_lines)
 
     vim.schedule(function()
         api.nvim_buf_set_text(0, line, col, line, col, suggestions)
-        local new_col = vim.fn.strcharlen(suggestions[#suggestions])
+        local new_col = #suggestions[#suggestions]
         -- For single-line suggestions, adjust the column position by adding the
         -- current column offset
         if #suggestions == 1 then


### PR DESCRIPTION
if suggestions contain full-width characters, the cursor movement caused by suggestion accepting is incorrect:

## Before
<img width="628" height="210" alt="image" src="https://github.com/user-attachments/assets/5e45973b-848b-4a25-abe9-8900a1ed400a" />

## After
<img width="584" height="206" alt="image" src="https://github.com/user-attachments/assets/df661cee-ae47-4ed2-80dc-401289900182" />
