### PR TITLE
Fix: fim whitespace passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,10 @@ default_config = {
     after_cursor_filter_length = 15,
     -- Similar to after_cursor_filter_length but trim the completion item from
     -- prefix instead of suffix.
+    --
+    -- Note: FIM completions bypass both filters and the surrounding whitespace
+    -- stripping entirely. FIM models emit intentional leading/trailing
+    -- whitespace, so their output is passed through unmodified.
     before_cursor_filter_length = 2,
     -- proxy port to use
     proxy = nil,

--- a/README.md
+++ b/README.md
@@ -752,19 +752,19 @@ default_config = {
     -- 20-character string that exactly matches the 20 characters following the
     -- cursor, the candidate will be truncated by those 20 characters before
     -- being delivered.
-    after_cursor_filter_length = 15,
+
+    -- The default is 0 for FIM model, and 15 for chat model
+    after_cursor_filter_length = function() end,
     -- Similar to after_cursor_filter_length but trim the completion item from
     -- prefix instead of suffix.
     --
-    -- Note: FIM completions bypass both filters and the surrounding whitespace
-    -- stripping entirely. FIM models emit intentional leading/trailing
-    -- whitespace, so their output is passed through unmodified.
+    -- Note: FIM completions do not strip surrounding whitespace by default.
+    -- Their default filter lengths are 0 because FIM models emit intentional
+    -- leading/trailing whitespace. Setting positive filter lengths keeps
+    -- duplicate context filtering enabled for FIM completions.
     --
-    -- For chat backends, setting both `after_cursor_filter_length` and
-    -- `before_cursor_filter_length` to 0 also disables text modification
-    -- (including the surrounding whitespace stripping) on completion
-    -- candidates.
-    before_cursor_filter_length = 2,
+    -- The default is 0 for FIM model, and 2 for chat model
+    before_cursor_filter_length = function() end,
     -- proxy port to use
     proxy = nil,
     -- **List** of functions to execute. If any function returns `false`, Minuet

--- a/README.md
+++ b/README.md
@@ -759,6 +759,11 @@ default_config = {
     -- Note: FIM completions bypass both filters and the surrounding whitespace
     -- stripping entirely. FIM models emit intentional leading/trailing
     -- whitespace, so their output is passed through unmodified.
+    --
+    -- For chat backends, setting both `after_cursor_filter_length` and
+    -- `before_cursor_filter_length` to 0 also disables text modification
+    -- (including the surrounding whitespace stripping) on completion
+    -- candidates.
     before_cursor_filter_length = 2,
     -- proxy port to use
     proxy = nil,

--- a/lua/minuet/backends/openai_base.lua
+++ b/lua/minuet/backends/openai_base.lua
@@ -11,8 +11,7 @@ function M.openai_get_text_fn_stream(json)
 end
 
 local function prepare_fim_items(items, context)
-    local filtered_items = common.filter_context_sequences_in_items(items, context)
-    return utils.remove_spaces(filtered_items, true)
+    return vim.tbl_filter(function(x) return type(x) == 'string' and x:find '%S' end, items)
 end
 
 function M.complete_openai_base(options, context, callback)

--- a/lua/minuet/backends/openai_base.lua
+++ b/lua/minuet/backends/openai_base.lua
@@ -11,7 +11,11 @@ function M.openai_get_text_fn_stream(json)
 end
 
 local function prepare_fim_items(items, context)
-    return vim.tbl_filter(function(x) return type(x) == 'string' and x:find '%S' end, items)
+    local filtered_items = common.filter_context_sequences_in_items(items, context)
+    local non_empty_items = vim.tbl_filter(function(x)
+        return type(x) == 'string' and x:find '%S' ~= nil
+    end, filtered_items)
+    return non_empty_items
 end
 
 function M.complete_openai_base(options, context, callback)

--- a/lua/minuet/config.lua
+++ b/lua/minuet/config.lua
@@ -120,6 +120,16 @@ local default_fim_suffix = function(_, context_after_cursor, _)
     return context_after_cursor
 end
 
+local function default_after_cursor_filter_length()
+    local config = require('minuet').config
+    return (config.provider == 'codestral' or config.provider == 'openai_fim_compatible') and 0 or 15
+end
+
+local function default_before_cursor_filter_length()
+    local config = require('minuet').config
+    return (config.provider == 'codestral' or config.provider == 'openai_fim_compatible') and 0 or 2
+end
+
 ---@class minuet.ChatInputExtraInfo
 ---@field is_incomplete_before boolean
 ---@field is_incomplete_after boolean
@@ -296,10 +306,10 @@ local M = {
     -- 20-character string that exactly matches the 20 characters following the
     -- cursor, the candidate will be truncated by those 20 characters before
     -- being delivered.
-    after_cursor_filter_length = 15,
+    after_cursor_filter_length = default_after_cursor_filter_length,
     -- Similar to after_cursor_filter_length but trim the completion item from
     -- prefix instead of suffix.
-    before_cursor_filter_length = 2,
+    before_cursor_filter_length = default_before_cursor_filter_length,
     proxy = nil,
 }
 

--- a/lua/minuet/utils.lua
+++ b/lua/minuet/utils.lua
@@ -307,6 +307,8 @@ end
 ---@return string?
 function M.filter_text(text, context)
     local config = require('minuet').config
+    local before_cursor_filter_length = M.get_or_eval_value(config.before_cursor_filter_length)
+    local after_cursor_filter_length = M.get_or_eval_value(config.after_cursor_filter_length)
 
     -- Handle nil values
     if not text or not context then
@@ -321,7 +323,7 @@ function M.filter_text(text, context)
         return text
     end
 
-    if config.before_cursor_filter_length <= 0 and config.after_cursor_filter_length <= 0 then
+    if before_cursor_filter_length <= 0 and after_cursor_filter_length <= 0 then
         return text
     end
 
@@ -336,20 +338,20 @@ function M.filter_text(text, context)
     local filtered_text = text
 
     -- Filter based on context before cursor (trim from the beginning of completion)
-    if lines_before and config.before_cursor_filter_length > 0 then
+    if lines_before and before_cursor_filter_length > 0 then
         local match_before = M.find_longest_match(filtered_text, lines_before)
         local match_len = vim.fn.strchars(match_before)
-        if match_before and match_len >= config.before_cursor_filter_length then
+        if match_before and match_len >= before_cursor_filter_length then
             -- Remove the matching part from the beginning of the completion
             filtered_text = vim.fn.strcharpart(filtered_text, match_len)
         end
     end
 
     -- Filter based on context after cursor (trim from the end of completion)
-    if lines_after and config.after_cursor_filter_length > 0 then
+    if lines_after and after_cursor_filter_length > 0 then
         local match_after = M.find_longest_match(lines_after, filtered_text)
         local match_len = vim.fn.strchars(match_after)
-        if match_after and match_len >= config.after_cursor_filter_length then
+        if match_after and match_len >= after_cursor_filter_length then
             -- Remove the matching part from the end of the completion
             local text_len = vim.fn.strchars(filtered_text)
             filtered_text = vim.fn.strcharpart(filtered_text, 0, text_len - match_len)

--- a/lua/minuet/utils.lua
+++ b/lua/minuet/utils.lua
@@ -321,6 +321,10 @@ function M.filter_text(text, context)
         return text
     end
 
+    if config.before_cursor_filter_length <= 0 and config.after_cursor_filter_length <= 0 then
+        return text
+    end
+
     text = M.remove_spaces_single(text or '', true)
     lines_before = M.remove_spaces_single(lines_before or '')
     lines_after = M.remove_spaces_single(lines_after or '')


### PR DESCRIPTION
I've implemented the FIM fix in two commits. I've split this in two commits. The first one does the FIM fix and the second changes `filter_text` to exit early in case the filter lengths are <= 0.

The reasoning is that changing providers is easy & supported, but currently `before_cursor_filter_length / after_cursor_filter_length` are not customizable per provider/model, so the simplest fix was to ignore these settings for FIM models; otherwise we'd have to make the filter lengths customizable per provider or expect the user to edit their config when changing to/from a FIM model. 

The second change is the early return on `filter_text` we talked about, it also affects not FIM models.

Feel free to revert this second commit or make changes.

Closes #140 