### PR TITLE
feat: support AWS Bedrock via curl and awscurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ default_config = {
     request_timeout = 3,
     -- Command used to make HTTP requests.
     curl_cmd = 'curl',
-    -- Extra arguments passed to curl (list of strings).
+    -- Extra arguments passed to curl (list of strings, or a function returning a list of strings).
     curl_extra_args = {},
     -- If completion item has multiple lines, create another completion item
     -- only containing its first line. This option only has impact for cmp and

--- a/lua/minuet/config.lua
+++ b/lua/minuet/config.lua
@@ -279,7 +279,8 @@ local M = {
     request_timeout = 3,
     -- Command used to make HTTP requests.
     curl_cmd = 'curl',
-    -- Extra arguments passed to curl (list of strings).
+    -- Extra arguments passed to curl (list of strings, or a function returning a list of strings).
+    ---@type string[] | fun(): string[]
     curl_extra_args = {},
     -- If completion item has multiple lines, create another completion item
     -- only containing its first line. This option only has impact for cmp and

--- a/lua/minuet/duet/backends/claude.lua
+++ b/lua/minuet/duet/backends/claude.lua
@@ -7,6 +7,10 @@ local function get_text_fn_stream(json)
     return json.delta.text
 end
 
+local function get_text_fn_no_steam(json)
+    return json.content[1].text
+end
+
 function M.complete(context, callback)
     local root_config = require('minuet').config
     local duet_config = root_config.duet
@@ -76,7 +80,14 @@ function M.complete(context, callback)
                 timestamp = timestamp,
             })
 
-            local text = utils.stream_decode(result, data_file, 'Claude', get_text_fn_stream)
+            local text
+
+            if options.stream then
+                text = utils.stream_decode(result, data_file, 'Claude', get_text_fn_stream)
+            else
+                text = utils.no_stream_decode(result, data_file, 'Claude', get_text_fn_no_steam)
+            end
+
             callback(text)
         end,
         on_spawn_error = function()

--- a/lua/minuet/duet/backends/claude.lua
+++ b/lua/minuet/duet/backends/claude.lua
@@ -7,10 +7,6 @@ local function get_text_fn_stream(json)
     return json.delta.text
 end
 
-local function get_text_fn_no_steam(json)
-    return json.content[1].text
-end
-
 function M.complete(context, callback)
     local root_config = require('minuet').config
     local duet_config = root_config.duet
@@ -80,14 +76,7 @@ function M.complete(context, callback)
                 timestamp = timestamp,
             })
 
-            local text
-
-            if options.stream then
-                text = utils.stream_decode(result, data_file, 'Claude', get_text_fn_stream)
-            else
-                text = utils.no_stream_decode(result, data_file, 'Claude', get_text_fn_no_steam)
-            end
-
+            local text = utils.stream_decode(result, data_file, 'Claude', get_text_fn_stream)
             callback(text)
         end,
         on_spawn_error = function()

--- a/lua/minuet/duet/utils.lua
+++ b/lua/minuet/duet/utils.lua
@@ -119,7 +119,6 @@ function M.make_curl_args(end_point, headers, data_file, timeout)
 end
 
 M.stream_decode = shared_utils.stream_decode
-M.no_stream_decode = shared_utils.no_stream_decode
 M.run_event = shared_utils.run_event
 
 function M.get_changedtick(bufnr)

--- a/lua/minuet/duet/utils.lua
+++ b/lua/minuet/duet/utils.lua
@@ -119,6 +119,7 @@ function M.make_curl_args(end_point, headers, data_file, timeout)
 end
 
 M.stream_decode = shared_utils.stream_decode
+M.no_stream_decode = shared_utils.no_stream_decode
 M.run_event = shared_utils.run_event
 
 function M.get_changedtick(bufnr)

--- a/lua/minuet/duet/utils.lua
+++ b/lua/minuet/duet/utils.lua
@@ -86,19 +86,25 @@ end
 
 function M.make_curl_args(end_point, headers, data_file, timeout)
     local root_config = M.get_root_config()
-    local args = { '-L' }
+    local curl_extra_args = M.get_or_eval_value(root_config.curl_extra_args)
+    local args = {}
 
-    for _, arg in ipairs(root_config.curl_extra_args or {}) do
+    for _, arg in ipairs(curl_extra_args or {}) do
         table.insert(args, arg)
     end
+
+    table.insert(args, '-L')
 
     for key, value in pairs(headers) do
         table.insert(args, '-H')
         table.insert(args, key .. ': ' .. value)
     end
 
-    table.insert(args, '--max-time')
-    table.insert(args, tostring(timeout))
+    if timeout > 0 then
+        table.insert(args, '--max-time')
+        table.insert(args, tostring(timeout))
+    end
+
     table.insert(args, '-d')
     table.insert(args, '@' .. data_file)
 

--- a/lua/minuet/utils.lua
+++ b/lua/minuet/utils.lua
@@ -686,7 +686,11 @@ function M.make_curl_args(end_point, headers, data_file)
     local config = require('minuet').config
 
     local args = {}
-    for _, arg in ipairs(config.curl_extra_args) do
+
+    local curl_extra_args = type(config.curl_extra_args) == 'function'
+        and config.curl_extra_args() or config.curl_extra_args
+
+    for _, arg in ipairs(curl_extra_args) do
         table.insert(args, arg)
     end
 

--- a/lua/minuet/utils.lua
+++ b/lua/minuet/utils.lua
@@ -685,17 +685,23 @@ end
 function M.make_curl_args(end_point, headers, data_file)
     local config = require('minuet').config
 
-    local args = { '-L' }
+    local args = {}
     for _, arg in ipairs(config.curl_extra_args) do
         table.insert(args, arg)
     end
+
+    table.insert(args, '-L')
 
     for k, v in pairs(headers) do
         table.insert(args, '-H')
         table.insert(args, k .. ': ' .. v)
     end
-    table.insert(args, '--max-time')
-    table.insert(args, tostring(config.request_timeout))
+
+    if config.request_timeout > 0 then
+        table.insert(args, '--max-time')
+        table.insert(args, tostring(config.request_timeout))
+    end
+
     table.insert(args, '-d')
     table.insert(args, '@' .. data_file)
 

--- a/lua/minuet/utils.lua
+++ b/lua/minuet/utils.lua
@@ -684,13 +684,10 @@ end
 ---@return string[]
 function M.make_curl_args(end_point, headers, data_file)
     local config = require('minuet').config
-
+    local curl_extra_args = M.get_or_eval_value(config.curl_extra_args)
     local args = {}
 
-    local curl_extra_args = type(config.curl_extra_args) == 'function'
-        and config.curl_extra_args() or config.curl_extra_args
-
-    for _, arg in ipairs(curl_extra_args) do
+    for _, arg in ipairs(curl_extra_args or {}) do
         table.insert(args, arg)
     end
 


### PR DESCRIPTION
Hi! This is my first PR here. I wanted to use minuet with Bedrock via AWS credentials, 
and made these changes to support that use case. I've tested it with both curl and awscurl 
against Bedrock (ap-northeast-1, claude-haiku-4-5).

- Make curl argument construction compatible with [awscurl](https://github.com/okigan/awscurl)
  (example use case: https://github.com/milanglacier/minuet-ai.nvim/issues/95#issuecomment-4500074644)
  - Move the `-L` flag after `curl_extra_args` so that it is passed to the underlying command
    (e.g. `awscurl`) rather than to `timeout`.
  - Skip setting `--max-time` (unsupported by awscurl) when the timeout is 0.
- Allow `curl_extra_args` to accept a function, enabling short-lived AWS credentials
  to be dynamically injected via curl's `--aws-sigv4` and `--user` options.
  This allows minuet to work with Bedrock using plain curl, without awscurl (see example below).


```lua
-- lua/local_config.lua
return {
  minuet_provider = 'claude',
  minuet_use_bedrock = true,
}

-- local_secrets.lua
return {
  minuet_aws_profile = 'aws-profile-for-minuet',
  minuet_claude_bedrock_endpoint =
  'https://bedrock-runtime.ap-northeast-1.amazonaws.com/model/global.anthropic.claude-haiku-4-5-20251001-v1:0/invoke',
}

-- init.lua
local use_aws_credential = function(aws_profile)
  -- full implemtation: https://github.com/iinm/dotfiles/blob/3a6d48faf63410fab455a685bd92088ab5e346bf/.config/nvim/init.lua#L736-L812
  return {
    get_aws_credentials = get_aws_credentials
  }
end

local setup_minuet = function()
  local local_config = require_safe('local_config')
  local local_secrets = require_safe('local_secrets')

  local use_bedrock = local_config.minuet_use_bedrock or false
  local aws_creds = use_bedrock and local_secrets.minuet_aws_profile
      and use_aws_credential(local_secrets.minuet_aws_profile)

  require('minuet').setup({
    provider = local_config.minuet_provider or 'claude',
    request_timeout = 5,

    curl_extra_args = use_bedrock
        and function()
          local creds = aws_creds and aws_creds.get_aws_credentials()
          if not creds then
            return {}
          end

          local user = creds.access_key .. ':' .. creds.secret_key
          return {
            '-H', 'X-Amz-Security-Token:' .. creds.session_token,
            '--aws-sigv4', 'aws:amz:ap-northeast-1:bedrock',
            '--user', user,
            '-X', 'POST',
          }
        end
        or nil,

    provider_options = {
      claude = use_bedrock and {
        end_point = local_secrets.minuet_claude_bedrock_endpoint,
        optional = {
          anthropic_version = 'bedrock-2023-05-31',
        },
        api_key = function()
          return 'dummy'
        end,
        stream = false,
        transform = {
          function(opts)
            opts.headers['x-api-key'] = nil
            opts.headers['anthropic-version'] = nil
            opts.body['model'] = nil
            opts.body['stream'] = nil
            -- print(vim.inspect(opts))
            return opts
          end
        }
      } or {
        model = 'claude-haiku-4-5',
        end_point = (local_secrets.minuet_anthropic_end_point or 'https://api.anthropic.com') .. '/v1/messages',
        api_key = function()
          return local_secrets.minuet_anthropic_api_key
        end
      },
    },
  })
end
```
